### PR TITLE
티켓팅 안내 회전시 여백, 가로 오버플로우 이슈

### DIFF
--- a/public/assets/css/ticketing-info.css
+++ b/public/assets/css/ticketing-info.css
@@ -18,19 +18,19 @@
 @media (min-width: 576px) {
     .ticketing-info {
         /* background-position-x: center; */
-        height: 213px;
+        height: 243px;
     }
 }
 @media (min-width: 768px) {
     .ticketing-info {
         /* background-position-x: 53%; */
-        height: 313px;
+        height: 363px;
     }
 }
 @media (min-width: 992px) {
     .ticketing-info {
         /* background-position-x: center; */
-        height: 313px;
+        height: 413px;
     }
 }
 @media (min-width: 1200px) {
@@ -42,5 +42,6 @@
 @media (min-width: 1400px) {
     .ticketing-info {
         /* background-position: center; */
+        height: 613px;
     }
 }

--- a/public/assets/css/ticketing-info.css
+++ b/public/assets/css/ticketing-info.css
@@ -1,45 +1,46 @@
 .ticketing-info {
-    background-image: url('../img/ticketing-container-mapped.png');
+    /* background-image: url('../img/ticketing-container-mapped.png');
     background-repeat: no-repeat;
     background-position: center;
-    background-size: cover;
+    background-size: cover; */
     height: 513px;
+    padding: 0 !important;
 }
 
 
 @media (max-width: 576px) {
     .ticketing-info {
-        background-position-x: center;
-        background-image: url('../img/ticketing-container.png');
+        /* background-position-x: center;
+        background-image: url('../img/ticketing-container.png'); */
         height: 175px;
     }
 }
 @media (min-width: 576px) {
     .ticketing-info {
-        background-position-x: center;
+        /* background-position-x: center; */
         height: 213px;
     }
 }
 @media (min-width: 768px) {
     .ticketing-info {
-        background-position-x: 53%;
+        /* background-position-x: 53%; */
         height: 313px;
     }
 }
 @media (min-width: 992px) {
     .ticketing-info {
-        background-position-x: center;
+        /* background-position-x: center; */
         height: 313px;
     }
 }
 @media (min-width: 1200px) {
     .ticketing-info {
-        background-position-x: 55%;
+        /* background-position-x: 55%; */
         height: 513px;
     }
 }
 @media (min-width: 1400px) {
     .ticketing-info {
-        background-position: center;
+        /* background-position: center; */
     }
 }

--- a/public/index.html
+++ b/public/index.html
@@ -330,6 +330,7 @@
             <div class="row">
                 <div class="col-12 ticketing-info">
                     <!-- <img src="assets/img/ticketing-container-mapped.png" alt=""> -->
+                    <canvas id="ticketing-info-canvas"></canvas>
                 </div>
             </div>
         </div>
@@ -349,5 +350,6 @@
             src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.1/dist/js/bootstrap.bundle.min.js"
             integrity="sha384-gtEjrD/SeCtmISkJkNUaaKMoLD0//ElJ19smozuHV6z3Iehds+3Ulb9Bn9Plx0x4"
             crossorigin="anonymous"></script>
+        <script src="src/ticketing-info.js"></script>
     </body>
 </html>

--- a/public/src/ticketing-info.js
+++ b/public/src/ticketing-info.js
@@ -1,0 +1,40 @@
+const ticketingCanvas = document.getElementById('ticketing-info-canvas');
+const ctx = ticketingCanvas.getContext('2d');
+ctx.imageSmoothingEnabled = true;
+
+const pixelRatio = window.devicePixelRatio;
+
+function setCanvasBlockSize() {
+    const rect = document.querySelector('div.ticketing-info').getBoundingClientRect();
+    console.log(ticketingCanvas);
+    ticketingCanvas.style.width = `${rect.width}px`;
+    ticketingCanvas.style.height = `${rect.height}px`;
+    ticketingCanvas.width = rect.width * pixelRatio;
+    ticketingCanvas.height = rect.height * pixelRatio;
+}
+
+function imgLoader(url) {
+    return new Promise((resolve, reject) => {
+        let img = new Image();
+        img.onload = () => {
+            resolve(img);
+        }
+        img.src = url;
+    })
+}
+
+window.addEventListener('resize', (e) => {
+    setCanvasBlockSize();
+})
+setCanvasBlockSize();
+
+Promise.all([
+    imgLoader('./assets/img/ticketing-container.png'), 
+    imgLoader('./assets/img/ticketing-container-mapped.png'), 
+])
+.then(imgList => {
+    const [ticketingContainer, ticketingContainerMapped] = imgList;
+    ctx.translate(ticketingCanvas.width / 2, ticketingCanvas.height / 2);
+    ctx.rotate(-3 * Math.PI / 180);
+    ctx.drawImage(ticketingContainerMapped, (-ticketingContainerMapped.width) / 2, -ticketingContainerMapped.height / 2);
+})

--- a/public/src/ticketing-info.js
+++ b/public/src/ticketing-info.js
@@ -32,26 +32,6 @@ function imgLoader(url) {
     })
 }
 
-// y = ax, what is a ?
-function getLinearFuncAlpha(deg) {
-    const theta = -1 * deg * Math.PI / 180;
-    // (1, y), what is y?
-    const y = Math.sin(theta);
-    const x = Math.cos(theta);
-    //          (y - 0)
-    //  alpha = -------
-    //          (x - 0)
-    const alpha = (y - 0) / (x - 0);
-    // console.log(theta, x, y, alpha);
-    return alpha === Infinity ? 0 : alpha;
-}
-
-// calc y = ax + beta
-function minMaxY(deg, minX, maxX, beta) {
-    // console.log(minX, maxX);
-    return [getLinearFuncAlpha(deg) * minX + (beta || 0), getLinearFuncAlpha(deg) * maxX - (beta || 0)]
-}
-
 class TicketImg {
     constructor(x, y, img) {
         this.x = x;
@@ -79,15 +59,15 @@ class TicketImg {
     // calc y = ax + beta
     minMaxY(deg, minX, maxX, beta) {
         // console.log(minX, maxX);
-        return [getLinearFuncAlpha(deg) * minX + (beta || 0), getLinearFuncAlpha(deg) * maxX - (beta || 0)]
+        return [this.getLinearFuncAlpha(deg) * minX + (beta || 0), this.getLinearFuncAlpha(deg) * maxX - (beta || 0)]
     }
 
     update(degree, rect) {
-        const [leftY, rightY] = minMaxY(degree, -rect.width / 2, rect.width / 2, 0);
+        const [leftY, rightY] = this.minMaxY(degree, -rect.width / 2, rect.width / 2, 0);
         console.log(`[leftY, rightY] ${[leftY - this.img.height / 2, rightY + this.img.height / 2]}`);
         const rotatedImgHeight = this.originImg.height + Math.abs(leftY) + Math.abs(rightY) + this.threshold;
         this.scale = rect.height / rotatedImgHeight;
-        console.log(getLinearFuncAlpha(degree), this.scale, rotatedImgHeight, this.originImg.height, 'w', -rect.width / 2, rect.width / 2);
+        console.log(this.getLinearFuncAlpha(degree), this.scale, rotatedImgHeight, this.originImg.height, 'w', -rect.width / 2, rect.width / 2);
     }
 
     draw(degree, rect) {
@@ -106,7 +86,7 @@ class TicketImg {
             ctx.fillStyle = 'rgba(155, 155, 155, 0.5)'
             ctx.fillRect(renderX + this.img.width * this.scale / 2 - 10 + this.x * pixelRatio, renderY + this.img.height * this.scale / 2 - 10 + this.y * pixelRatio, 20, 20)
         }
-        console.log(minMaxY(degree, -rect.width / 2, rect.width / 2, 0), getLinearFuncAlpha(degree));
+        console.log(this.minMaxY(degree, -rect.width / 2, rect.width / 2, 0), this.getLinearFuncAlpha(degree));
 
 
         ctx.translate(0, 0);

--- a/public/src/ticketing-info.js
+++ b/public/src/ticketing-info.js
@@ -3,10 +3,11 @@ const ctx = ticketingCanvas.getContext('2d');
 ctx.imageSmoothingEnabled = true;
 
 const pixelRatio = window.devicePixelRatio;
+console.log(`pixelRatio: ${pixelRatio}`);
 
 function setCanvasBlockSize() {
     const rect = document.querySelector('div.ticketing-info').getBoundingClientRect();
-    console.log(ticketingCanvas);
+    // console.log(ticketingCanvas);
     ticketingCanvas.style.width = `${rect.width}px`;
     ticketingCanvas.style.height = `${rect.height}px`;
     ticketingCanvas.width = rect.width * pixelRatio;
@@ -23,6 +24,80 @@ function imgLoader(url) {
     })
 }
 
+// y = ax, what is a ?
+function getLinearFuncAlpha(deg) {
+    const theta = -1 * deg * Math.PI / 180;
+    // (1, y), what is y?
+    const y = Math.sin(theta);
+    const x = Math.cos(theta);
+    //          (y - 0)
+    //  alpha = -------
+    //          (x - 0)
+    const alpha = (y - 0) / (x - 0);
+    // console.log(theta, x, y, alpha);
+    return alpha === Infinity ? 0 : alpha;
+}
+
+// calc y = ax + beta
+function minMaxY(deg, minX, maxX, beta) {
+    // console.log(minX, maxX);
+    return [getLinearFuncAlpha(deg) * minX + (beta || 0), getLinearFuncAlpha(deg) * maxX - (beta || 0)]
+}
+
+class TicketImg {
+    constructor(x, y, img) {
+        this.x = x;
+        this.y = y;
+        this.img = img;
+        this.originImg = img;
+        this.scale = 1;
+    }
+    
+    // y = ax, what is a ?
+    getLinearFuncAlpha(deg) {
+        const theta = -1 * deg * Math.PI / 180;
+        // (1, y), what is y?
+        const y = Math.sin(theta);
+        const x = Math.cos(theta);
+        //          (y - 0)
+        //  alpha = -------
+        //          (x - 0)
+        const alpha = (y - 0) / (x - 0);
+        // console.log(theta, x, y, alpha);
+        return alpha === Infinity ? 0 : alpha;
+    }
+
+    // calc y = ax + beta
+    minMaxY(deg, minX, maxX, beta) {
+        // console.log(minX, maxX);
+        return [getLinearFuncAlpha(deg) * minX + (beta || 0), getLinearFuncAlpha(deg) * maxX - (beta || 0)]
+    }
+
+    update(degree, rect) {
+        const [leftY, rightY] = minMaxY(degree, -rect.width / 2, rect.width / 2, 0);
+        const rotatedImgHeight = this.originImg.height + Math.abs(leftY) + Math.abs(rightY);
+        this.scale = rect.height / rotatedImgHeight;
+        console.log(this.scale, rotatedImgHeight, this.originImg.height, 'w', -rect.width / 2, rect.width / 2);
+    }
+
+    draw(degree, rect) {
+        console.log(rect);
+
+        console.log(this.x, this.y, this.scale);
+        const [renderX, renderY] = [-(this.img.width * this.scale) / 2, -(this.img.height * this.scale) / 2];
+        console.log('render', renderX, renderY);
+        ctx.translate(rect.width / 2, rect.height / 2);
+        ctx.rotate(degree * Math.PI / 180);
+        // ctx.drawImage(this.img, (-rect.width) * this.scale, (-rect.height / 2) * this.scale, this.img.width * this.scale, this.img.height * this.scale);
+        ctx.drawImage(this.img, renderX, renderY, this.img.width * this.scale, this.img.height * this.scale);
+        ctx.fillStyle = 'rgba(155, 0, 0, 0.5)';
+        ctx.fillRect(renderX, renderY, this.img.width * this.scale, this.img.height * this.scale);
+        ctx.fillStyle = 'rgba(155, 155, 155, 0.5)'
+        ctx.fillRect(renderX + this.img.width * this.scale / 2 - 10 + this.x, renderY + this.img.height * this.scale / 2 - 10 + this.y, 20, 20)
+        console.log(minMaxY(degree, -rect.width / 2, rect.width / 2, 0), getLinearFuncAlpha(degree));
+    }
+}
+
 window.addEventListener('resize', (e) => {
     setCanvasBlockSize();
 })
@@ -33,8 +108,12 @@ Promise.all([
     imgLoader('./assets/img/ticketing-container-mapped.png'), 
 ])
 .then(imgList => {
+    const degree = -3;
     const [ticketingContainer, ticketingContainerMapped] = imgList;
-    ctx.translate(ticketingCanvas.width / 2, ticketingCanvas.height / 2);
-    ctx.rotate(-3 * Math.PI / 180);
-    ctx.drawImage(ticketingContainerMapped, (-ticketingContainerMapped.width) / 2, -ticketingContainerMapped.height / 2);
+    const ticketMapped = new TicketImg(0, 0, ticketingContainerMapped);
+    const rect = ticketingCanvas.getBoundingClientRect();
+    rect.width = rect.width * pixelRatio;
+    rect.height = rect.height * pixelRatio;
+    ticketMapped.update(degree, rect);
+    ticketMapped.draw(degree, rect);
 })

--- a/public/src/ticketing-info.js
+++ b/public/src/ticketing-info.js
@@ -99,12 +99,12 @@ class TicketImg {
         ctx.translate(rect.width / 2, rect.height / 2);
         ctx.rotate(degree * Math.PI / 180);
         // ctx.drawImage(this.img, (-rect.width) * this.scale, (-rect.height / 2) * this.scale, this.img.width * this.scale, this.img.height * this.scale);
-        ctx.drawImage(this.img, renderX, renderY, this.img.width * this.scale, this.img.height * this.scale);
+        ctx.drawImage(this.img, renderX + this.x * pixelRatio, renderY + this.y, this.img.width * this.scale, this.img.height * this.scale);
         if(DEBUG_MODE) {
             ctx.fillStyle = 'rgba(155, 0, 0, 0.5)';
-            ctx.fillRect(renderX, renderY, this.img.width * this.scale, this.img.height * this.scale);
+            ctx.fillRect(renderX + this.x * pixelRatio, renderY + this.y * pixelRatio, this.img.width * this.scale, this.img.height * this.scale);
             ctx.fillStyle = 'rgba(155, 155, 155, 0.5)'
-            ctx.fillRect(renderX + this.img.width * this.scale / 2 - 10 + this.x, renderY + this.img.height * this.scale / 2 - 10 + this.y, 20, 20)
+            ctx.fillRect(renderX + this.img.width * this.scale / 2 - 10 + this.x * pixelRatio, renderY + this.img.height * this.scale / 2 - 10 + this.y * pixelRatio, 20, 20)
         }
         console.log(minMaxY(degree, -rect.width / 2, rect.width / 2, 0), getLinearFuncAlpha(degree));
 
@@ -132,9 +132,29 @@ Promise.all([
     render();
 })
 
+function responsivePosition(width) {
+    console.log('w', width, 1400 <= width);
+    if (0 <= width && width < 576) {
+        return [-25, 0];
+    } else if (576 <= width && width < 768) {
+        return [0, 0];
+    } else if (768 <= width && width < 992) {
+        return [-35, 0];
+    } else if (992 <= width && width < 1200) {
+        return [0, 0];
+    } else if (1200 <= width && width < 1400) {
+        return [0, 0];
+    } else if (1400 <= width) {
+        return [0, 0];
+    }
+}
+
 function render() {
     ctx.clearRect(0, 0, canvasBoundingRect.width, canvasBoundingRect.height);
+    const [x, y] = responsivePosition(ticketingCanvas.getBoundingClientRect().width);
     if (ticketMapped) {
+        ticketMapped.x = x;
+        ticketMapped.y = y;
         ticketMapped.update(angle, canvasBoundingRect);
         ticketMapped.draw(angle, canvasBoundingRect);  
     }


### PR DESCRIPTION
![스크린샷 2021-06-15 오후 5 00 16](https://user-images.githubusercontent.com/16532326/122018459-d7732680-cdfd-11eb-9778-caab91cc3104.png)

티켓팅 안내 이미지를 단순 회전 시키면 이미지가 렌더링 되어지는 가로 크기에 따라서 `가로 스크롤` 이 생기고, 양 끝에 `하얀색 여백`이 생겨지는 문제 존재하였음

이 부분을 캔버스 렌더링 방식과 비율에 따른 자동 스케일링, 반응형 좌표 이동을 개발하여 해결함

![스크린샷 2021-06-15 오후 10 44 31](https://user-images.githubusercontent.com/16532326/122063507-4ca92080-ce2b-11eb-98c1-5e34fac87032.png)
위 그림의 경우 회전하면 회전 각에 따라 양 끝점의 좌표가 y = ax + b 에 의해 대략적으로 예측 되어짐

![스크린샷 2021-06-15 오후 11 17 33](https://user-images.githubusercontent.com/16532326/122069153-ea9eea00-ce2f-11eb-9407-13c6c81c66f4.png)
예를들어 대략 3도 정도 기울였을시 `cos(3° * Math.PI / 180)` 로 x, 
`sin(3° * Math.PI / 180)` 로 y 값이 `(0.999, 0.0519)` 로 구해지면
![스크린샷 2021-06-15 오후 11 20 44](https://user-images.githubusercontent.com/16532326/122069641-51240800-ce30-11eb-98c0-c8d89e84b17e.png)
원점을 지나는 일차 함수의 기울기를 구할 수 있음

이를 이용하여 이미지가 렌더링 되어질 전체 높이 크기를 구한 다음 
![스크린샷 2021-06-15 오후 10 47 16](https://user-images.githubusercontent.com/16532326/122063945-ac073080-ce2b-11eb-97d1-2477c47cab9a.png)
그려질 캔버스 높이 크기와 비율을 계산하여 축소시킨 이미지로 렌더링 함

![스크린샷 2021-06-15 오후 10 48 54](https://user-images.githubusercontent.com/16532326/122064143-de189280-ce2b-11eb-81ac-7d484625dc2a.png)
물론 브라우저 크기 변화에 따라 다시 렌더링해야 할 경우엔 이벤트 리스너 등록시켜서 렌더링 호출 시킴